### PR TITLE
updating readme to fix installation on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ If instead you do not wish to add CUDA support, you can instead do:
 pip install dexp
 ```
 
+**For OSX users:** Before installating dexp, you will first need to install cairo:
+```
+brew install cairo
+```
+
 ### Quick one-line environment setup and installation:
 
 The following line will delete any existing dexp environment, recreate it, and install **dexp** with support for CUDA 11.2:


### PR DESCRIPTION
- update on readme that tells OSX users to install cairo first