### PR TITLE
Added dexp command line arguments tracking

### DIFF
--- a/dexp/cli/dexp_commands/copy.py
+++ b/dexp/cli/dexp_commands/copy.py
@@ -3,7 +3,7 @@ from arbol.arbol import aprint, asection
 
 from dexp.cli.dexp_main import _default_clevel, _default_codec, _default_store
 from dexp.cli.dexp_main import _default_workers_backend
-from dexp.cli.parsing import _parse_channels, _get_output_path, _parse_slicing
+from dexp.cli.parsing import _parse_channels, _get_output_path, _parse_slicing, _parse_chunks
 from dexp.datasets.open_dataset import glob_datasets
 from dexp.datasets.operations.copy import dataset_copy
 
@@ -14,6 +14,7 @@ from dexp.datasets.operations.copy import dataset_copy
 @click.option('--channels', '-c', default=None, help='List of channels, all channels when ommited.')
 @click.option('--slicing', '-s', default=None, help='Dataset slice (TZYX), e.g. [0:5] (first five stacks) [:,0:100] (cropping in z) ')
 @click.option('--store', '-st', default=_default_store, help='Zarr store: ‘dir’, ‘ndir’, or ‘zip’', show_default=True)
+@click.option('--chunks', '-chk', default=None, help='Dataset chunks dimensions, e.g. (1, 126, 512, 512).')
 @click.option('--codec', '-z', default=_default_codec, help='Compression codec: zstd for ’, ‘blosclz’, ‘lz4’, ‘lz4hc’, ‘zlib’ or ‘snappy’ ', show_default=True)
 @click.option('--clevel', '-l', type=int, default=_default_clevel, help='Compression level', show_default=True)
 @click.option('--overwrite', '-w', is_flag=True, help='Forces overwrite of target', show_default=True)
@@ -26,6 +27,7 @@ def copy(input_paths,
          channels,
          slicing,
          store,
+         chunks,
          codec,
          clevel,
          overwrite,
@@ -40,6 +42,7 @@ def copy(input_paths,
     output_path = _get_output_path(input_paths[0], output_path, '_copy')
     slicing = _parse_slicing(slicing)
     channels = _parse_channels(input_dataset, channels)
+    chunks = _parse_chunks(chunks)
 
     with asection(f"Copying from: {input_paths} to {output_path} for channels: {channels}, slicing: {slicing} "):
         dataset_copy(input_dataset,
@@ -47,6 +50,7 @@ def copy(input_paths,
                      channels=channels,
                      slicing=slicing,
                      store=store,
+                     chunks=chunks,
                      compression=codec,
                      compression_level=clevel,
                      overwrite=overwrite,

--- a/dexp/cli/dexp_commands/stabilize.py
+++ b/dexp/cli/dexp_commands/stabilize.py
@@ -12,6 +12,7 @@ from dexp.datasets.operations.stabilize import dataset_stabilize
 @click.argument('input_paths', nargs=-1)  # ,  help='input path'
 @click.option('--output_path', '-o')  # , help='output path'
 @click.option('--channels', '-c', default=None, help='List of channels, all channels when omitted.')
+@click.option('--reference-channel', '-rc', default=None, help='Reference channel for single stabilization model computation.')
 @click.option('--slicing', '-s', default=None, help='Dataset slice (TZYX), e.g. [0:5] (first five stacks) [:,0:100] (cropping in z) ')
 @click.option('--store', '-st', default=_default_store, help='Zarr store: ‘dir’, ‘ndir’, or ‘zip’', show_default=True)
 @click.option('--codec', '-z', default=_default_codec, help='Compression codec: ‘zstd’, ‘blosclz’, ‘lz4’, ‘lz4hc’, ‘zlib’ or ‘snappy’ ', show_default=True)
@@ -39,6 +40,7 @@ from dexp.datasets.operations.stabilize import dataset_stabilize
 def stabilize(input_paths,
               output_path,
               channels,
+              reference_channel,
               slicing,
               store,
               codec,
@@ -75,6 +77,7 @@ def stabilize(input_paths,
         dataset_stabilize(input_dataset,
                           output_path,
                           channels=channels,
+                          reference_channel=reference_channel,
                           slicing=slicing,
                           zarr_store=store,
                           compression_codec=codec,

--- a/dexp/cli/dexp_commands/stabilize.py
+++ b/dexp/cli/dexp_commands/stabilize.py
@@ -29,6 +29,8 @@ from dexp.datasets.operations.stabilize import dataset_stabilize
 @click.option('--dsigma', '-ds', type=float, default=1.5, help='Sigma for Gaussian smoothing (crude denoising) of input images, zero to disable.', show_default=True)
 @click.option('--logcomp', '-lc', type=bool, default=True, help='Applies the function log1p to the images to compress high-intensities (usefull when very (too) bright structures are present in the images, such as beads.', show_default=True)
 @click.option('--edgefilter', '-ef', type=bool, default=False, help='Applies sobel edge filter to input images.', show_default=True)
+@click.option('--detrend', '-dt', type=bool, is_flag=True, default=False, help='Remove linear trend from stabilization result', show_default=True)
+@click.option('--maxproj/--no-maxproj', '-mp/-nmp', type=bool, default=True, help='Registers using only the maximum intensity projection from each stack.', show_default=True)
 @click.option('--workers', '-k', type=int, default=-4, help='Number of worker threads to spawn. Negative numbers n correspond to: number_of _cores / |n|. Be careful, starting two many workers is know to cause trouble (unfortunately unclear why!).',
               show_default=True)
 @click.option('--workersbackend', '-wkb', type=str, default=_default_workers_backend, help='What backend to spawn workers with, can be ‘loky’ (multi-process) or ‘threading’ (multi-thread) ', show_default=True)  #
@@ -54,6 +56,8 @@ def stabilize(input_paths,
               dsigma,
               logcomp,
               edgefilter,
+              detrend,
+              maxproj,
               workers,
               workersbackend,
               device,
@@ -88,6 +92,8 @@ def stabilize(input_paths,
                           denoise_input_sigma=dsigma,
                           log_compression=logcomp,
                           edge_filter=edgefilter,
+                          detrend=detrend,
+                          maxproj=maxproj,
                           workers=workers,
                           workers_backend=workersbackend,
                           device=device,

--- a/dexp/cli/parsing.py
+++ b/dexp/cli/parsing.py
@@ -1,5 +1,6 @@
 from arbol import aprint
 from numpy import s_
+from typing import Tuple, Optional
 
 
 def _get_output_path(input_path, output_path, postfix=''):
@@ -55,3 +56,9 @@ def _parse_devices(devices):
         devices = tuple(int(device.strip()) for device in devices.split(','))
 
     return devices
+
+
+def _parse_chunks(chunks: Optional[str]) -> Optional[Tuple[int]]:
+    if chunks is not None:
+        chunks = eval(chunks)
+    return chunks

--- a/dexp/datasets/operations/copy.py
+++ b/dexp/datasets/operations/copy.py
@@ -1,5 +1,5 @@
 import os
-from typing import Sequence
+from typing import Sequence, Optional
 
 import numpy
 from arbol.arbol import aprint, asection
@@ -12,6 +12,7 @@ def dataset_copy(dataset: BaseDataset,
                  channels: Sequence[str],
                  slicing,
                  store: str,
+                 chunks: Optional[Sequence[int]],
                  compression: str,
                  compression_level: int,
                  overwrite: bool,
@@ -36,7 +37,8 @@ def dataset_copy(dataset: BaseDataset,
 
             shape = array.shape
             dtype = array.dtype
-            chunks = ZDataset._default_chunks
+            if chunks is None:
+                chunks = ZDataset._default_chunks
 
             dest_dataset.add_channel(name=channel,
                                      shape=shape,
@@ -72,5 +74,6 @@ def dataset_copy(dataset: BaseDataset,
     if check:
         dest_dataset.check_integrity()
 
+    dest_dataset.set_cli_history(parent=dataset if isinstance(dataset, ZDataset) else None)
     # close destination dataset:
     dest_dataset.close()

--- a/dexp/datasets/operations/deconv.py
+++ b/dexp/datasets/operations/deconv.py
@@ -166,5 +166,6 @@ def dataset_deconv(dataset: BaseDataset,
     if check:
         dest_dataset.check_integrity()
 
+    dest_dataset.set_cli_history(parent=dataset if isinstance(dataset, ZDataset) else None)
     # close destination dataset:
     dest_dataset.close()

--- a/dexp/datasets/operations/deskew.py
+++ b/dexp/datasets/operations/deskew.py
@@ -113,5 +113,6 @@ def dataset_deskew(dataset,
     if check:
         dest_dataset.check_integrity()
 
+    dest_dataset.set_cli_history(parent=dataset if isinstance(dataset, ZDataset) else None)
     # close destination dataset:
     dest_dataset.close()

--- a/dexp/datasets/operations/fuse.py
+++ b/dexp/datasets/operations/fuse.py
@@ -202,5 +202,6 @@ def dataset_fuse(dataset,
     if check:
         dest_dataset.check_integrity()
 
+    dest_dataset.set_cli_history(parent=dataset if isinstance(dataset, ZDataset) else None)
     # close destination dataset:
     dest_dataset.close()

--- a/dexp/datasets/operations/isonet.py
+++ b/dexp/datasets/operations/isonet.py
@@ -107,5 +107,6 @@ def dataset_isonet(dataset: BaseDataset,
         if check:
             dest_dataset.check_integrity()
 
+        dest_dataset.set_cli_history(parent=dataset if isinstance(dataset, ZDataset) else None)
         # close destination dataset:
         dest_dataset.close()

--- a/dexp/datasets/operations/stabilize.py
+++ b/dexp/datasets/operations/stabilize.py
@@ -220,5 +220,6 @@ def dataset_stabilize(input_dataset: BaseDataset,
     if check:
         output_dataset.check_integrity()
 
+    output_dataset.set_cli_history(parent=input_dataset if isinstance(input_dataset, ZDataset) else None)
     # close destination dataset:
     output_dataset.close()

--- a/dexp/datasets/operations/stabilize.py
+++ b/dexp/datasets/operations/stabilize.py
@@ -1,5 +1,5 @@
 import os
-from typing import Sequence
+from typing import Sequence, Optional
 
 import numpy
 from arbol.arbol import aprint
@@ -12,11 +12,106 @@ from dexp.processing.backends.best_backend import BestBackend
 from dexp.processing.backends.numpy_backend import NumpyBackend
 from dexp.processing.registration.sequence_proj import image_stabilisation_proj_
 from dexp.processing.registration.sequence import image_stabilisation
+from dexp.processing.registration.model.sequence_registration_model import SequenceRegistrationModel
+
+
+def _compute_model(
+        input_dataset: BaseDataset,
+        channel: str,
+        slicing,
+        max_range: int,
+        min_confidence: float,
+        enable_com: bool,
+        quantile: float,
+        tolerance: float,
+        order_error: float,
+        order_reg: float,
+        alpha_reg: float,
+        phase_correlogram_sigma: float,
+        denoise_input_sigma: float,
+        log_compression: bool,
+        edge_filter: bool,
+        detrend: bool = False,
+        maxproj: bool = True,
+        device: int = 0,
+        debug_output=None) -> SequenceRegistrationModel:
+
+    # get channel array:
+    array = input_dataset.get_array(channel, per_z_slice=False, wrap_with_dask=True)
+
+    # Perform slicing:
+    if slicing is not None:
+        array = array[slicing]
+
+    # Shape and chunks for array:
+    ndim = array.ndim
+
+    if not maxproj:
+        with BestBackend(device, enable_unified_memory=True):
+            model = image_stabilisation(
+                image=array,
+                axis=0,
+                detrend=detrend,
+                preload_images=False,
+                max_range=max_range,
+                min_confidence=min_confidence,
+                enable_com=enable_com,
+                quantile=quantile,
+                tolerance=tolerance,
+                order_error=order_error,
+                order_reg=order_reg,
+                alpha_reg=alpha_reg,
+                sigma=phase_correlogram_sigma,
+                denoise_input_sigma=denoise_input_sigma,
+                log_compression=log_compression,
+                edge_filter=edge_filter,
+                internal_dtype=numpy.float16,
+                debug_output=debug_output,
+            )
+            model.to_numpy()
+
+    else:  # stabilized with maximum intensity projection
+        projections = []
+        for axis in range(array.ndim - 1):
+            projection = input_dataset.get_projection_array(
+                channel=channel, axis=axis, wrap_with_dask=False
+            )
+            if slicing is not None:
+                projection = projection[slicing]
+
+            proj_axis = list(1 + a for a in range(array.ndim - 1) if a != axis)
+            projections.append((*proj_axis, projection))
+
+        # Perform stabilisation:
+        with BestBackend(device, enable_unified_memory=True):
+            model = image_stabilisation_proj_(
+                projections=projections,
+                max_range=max_range,
+                min_confidence=min_confidence,
+                enable_com=enable_com,
+                quantile=quantile,
+                tolerance=tolerance,
+                order_error=order_error,
+                order_reg=order_reg,
+                alpha_reg=alpha_reg,
+                sigma=phase_correlogram_sigma,
+                denoise_input_sigma=denoise_input_sigma,
+                log_compression=log_compression,
+                edge_filter=edge_filter,
+                ndim=ndim - 1,
+                internal_dtype=numpy.float16,
+                debug_output=debug_output,
+                detrend=detrend,
+            )
+            model.to_numpy()
+
+    return model
 
 
 def dataset_stabilize(input_dataset: BaseDataset,
                       output_path: str,
                       channels: Sequence[str],
+                      reference_channel: Optional[str] = None,
                       slicing=None,
                       zarr_store: str = "dir",
                       compression_codec: str = "zstd",
@@ -52,6 +147,7 @@ def dataset_stabilize(input_dataset: BaseDataset,
     input_dataset: Input dataset
     output_path: Output path for Zarr storage
     channels: selected channels
+    reference_channel: use this channel to compute the stabilization model and apply to every channel.
     slicing: selected array slicing
     zarr_store: type of store, can be 'dir', 'ndir', or 'zip'
     compression_codec: compression codec to be used ('zstd', 'blosclz', 'lz4', 'lz4hc', 'zlib' or 'snappy').
@@ -84,80 +180,61 @@ def dataset_stabilize(input_dataset: BaseDataset,
     mode = 'w' + ('' if overwrite else '-')
     output_dataset = ZDataset(output_path, mode, zarr_store)
 
+    model = None
+    if reference_channel is not None:
+        if reference_channel not in input_dataset.channels():
+            raise ValueError(f'Reference channel {reference_channel} not found.')
+        model = _compute_model(
+            input_dataset=input_dataset,
+            channel=reference_channel,
+            slicing=slicing,
+            max_range=max_range,
+            min_confidence=min_confidence,
+            enable_com=enable_com,
+            quantile=quantile,
+            tolerance=tolerance,
+            order_error=order_error,
+            order_reg=order_reg,
+            alpha_reg=alpha_reg,
+            phase_correlogram_sigma=phase_correlogram_sigma,
+            denoise_input_sigma=denoise_input_sigma,
+            log_compression=log_compression,
+            edge_filter=edge_filter,
+            detrend=detrend,
+            maxproj=maxproj,
+            device=device,
+            debug_output=debug_output,
+            )
+
     for channel in input_dataset._selected_channels(channels):
+        if reference_channel is None:
+            model = _compute_model(
+                input_dataset=input_dataset,
+                channel=channel,
+                slicing=slicing,
+                max_range=max_range,
+                min_confidence=min_confidence,
+                enable_com=enable_com,
+                quantile=quantile,
+                tolerance=tolerance,
+                order_error=order_error,
+                order_reg=order_reg,
+                alpha_reg=alpha_reg,
+                phase_correlogram_sigma=phase_correlogram_sigma,
+                denoise_input_sigma=denoise_input_sigma,
+                log_compression=log_compression,
+                edge_filter=edge_filter,
+                detrend=detrend,
+                maxproj=maxproj,
+                device=device,
+                debug_output=debug_output,
+            )
 
-        # get channel array:
         array = input_dataset.get_array(channel, per_z_slice=False, wrap_with_dask=True)
-
-        # Perform slicing:
-        if slicing is not None:
-            array = array[slicing]
-
-        # Shape and chunks for array:
-        ndim = array.ndim
         shape = array.shape
         dtype = array.dtype
         chunks = ZDataset._default_chunks
         nb_timepoints = shape[0]
-
-        if not maxproj:
-            with BestBackend(device, enable_unified_memory=True):
-                model = image_stabilisation(
-                    image=array,
-                    axis=0,
-                    detrend=detrend,
-                    preload_images=False,
-                    max_range=max_range,
-                    min_confidence=min_confidence,
-                    enable_com=enable_com,
-                    quantile=quantile,
-                    tolerance=tolerance,
-                    order_error=order_error,
-                    order_reg=order_reg,
-                    alpha_reg=alpha_reg,
-                    sigma=phase_correlogram_sigma,
-                    denoise_input_sigma=denoise_input_sigma,
-                    log_compression=log_compression,
-                    edge_filter=edge_filter,
-                    internal_dtype=numpy.float16,
-                    debug_output=debug_output,
-                )
-                model.to_numpy()
-
-        else:  # stabilized with maximum intensity projection
-            projections = []
-            for axis in range(array.ndim - 1):
-                projection = input_dataset.get_projection_array(
-                    channel=channel, axis=axis, wrap_with_dask=False
-                )
-                if slicing is not None:
-                    projection = projection[slicing]
-
-                proj_axis = list(1 + a for a in range(array.ndim - 1) if a != axis)
-                projections.append((*proj_axis, projection))
-
-            # Perform stabilisation:
-            with BestBackend(device, enable_unified_memory=True):
-                model = image_stabilisation_proj_(
-                    projections=projections,
-                    max_range=max_range,
-                    min_confidence=min_confidence,
-                    enable_com=enable_com,
-                    quantile=quantile,
-                    tolerance=tolerance,
-                    order_error=order_error,
-                    order_reg=order_reg,
-                    alpha_reg=alpha_reg,
-                    sigma=phase_correlogram_sigma,
-                    denoise_input_sigma=denoise_input_sigma,
-                    log_compression=log_compression,
-                    edge_filter=edge_filter,
-                    ndim=ndim - 1,
-                    internal_dtype=numpy.float16,
-                    debug_output=debug_output,
-                    detrend=detrend,
-                )
-                model.to_numpy()
 
         # Shape of the resulting array:
         padded_shape = (nb_timepoints,) + model.padded_shape(shape[1:])
@@ -172,7 +249,6 @@ def dataset_stabilize(input_dataset: BaseDataset,
 
         # definition of function that processes each time point:
         def process(tp):
-
             try:
                 with asection(f"Processing time point: {tp}/{nb_timepoints} ."):
                     with asection(f"Loading stack"):
@@ -192,8 +268,6 @@ def dataset_stabilize(input_dataset: BaseDataset,
                         output_dataset.write_stack(channel=channel,
                                                    time_point=tp,
                                                    stack_array=tp_array)
-
-
 
             except Exception as error:
                 aprint(error)

--- a/dexp/datasets/zarr_dataset.py
+++ b/dexp/datasets/zarr_dataset.py
@@ -193,7 +193,7 @@ class ZDataset(BaseDataset):
     def dtype(self, channel: str):
         return self.get_array(channel).dtype
 
-    def info(self, channel: str = None) -> str:
+    def info(self, channel: str = None, cli_history: bool = True) -> str:
         info_str = ''
         if channel:
             info_str += f"Channel: '{channel}', nb time points: {self.shape(channel)[0]}, shape: {self.shape(channel)[1:]}"
@@ -216,13 +216,14 @@ class ZDataset(BaseDataset):
             info_str += str(array.info)
             info_str += '\n'
 
-        key = 'cli_history'
-        if key in self._root_group.attrs:
-            info_str += "\nCommand line history:\n/\n"
-            commands_list = self._root_group.attrs[key]
-            for command in commands_list[:-1]:
-                info_str += " ├──" + command + "\n"
-            info_str += " └──" + commands_list[-1] + "\n"
+        if cli_history:
+            key = 'cli_history'
+            if key in self._root_group.attrs:
+                info_str += "\nCommand line history:\n/\n"
+                commands_list = self._root_group.attrs[key]
+                for command in commands_list[:-1]:
+                    info_str += " ├──" + command + "\n"
+                info_str += " └──" + commands_list[-1] + "\n"
 
         return info_str
 

--- a/dexp/datasets/zarr_dataset.py
+++ b/dexp/datasets/zarr_dataset.py
@@ -216,6 +216,14 @@ class ZDataset(BaseDataset):
             info_str += str(array.info)
             info_str += '\n'
 
+        key = 'cli_history'
+        if key in self._root_group.attrs:
+            info_str += "\nCommand line history:\n/\n"
+            commands_list = self._root_group.attrs[key]
+            for command in commands_list[:-1]:
+                info_str += " ├──" + command + "\n"
+            info_str += " └──" + commands_list[-1] + "\n"
+
         return info_str
 
     def get_metadata(self):
@@ -233,12 +241,10 @@ class ZDataset(BaseDataset):
             cli_history = parent_metadata.get(key, [])
 
         if key in self._root_group.attrs:
-            # TODO: this needs to be reevaluated, e.g. when a channel is copied from another dataset some
-            #  information might be lost since two histories would be necessary to keep track of both sources
-            raise ValueError(f'{key} attribute already exists on this dataset')
+            cli_history += self._root_group.attrs[key]
 
-        command = os.path.basename(sys.argv[0]) + ' ' + ' '.join(sys.argv[1:])
-        cli_history.append(command)
+        new_command = os.path.basename(sys.argv[0]) + ' ' + ' '.join(sys.argv[1:])
+        cli_history.append(new_command)
         self._root_group.attrs[key] = cli_history
 
     def get_array(self, channel: str, per_z_slice: bool = False, wrap_with_dask: bool = False):


### PR DESCRIPTION
With this change, DEXP's dataset keeps track of previous changes on the metadata keyword `cli_history`.

It is still unclear what is the best behavior when a new channel is added from another dataset. Should we keep both histories? What would be the ordering of these commands?
Anyway, this should be addressed in another commit.



