### PR TITLE
Fixed slicing for datasets with multiple channels

### DIFF
--- a/dexp/utils/slicing.py
+++ b/dexp/utils/slicing.py
@@ -1,0 +1,19 @@
+import numpy as np
+from typing import Tuple, List
+
+
+def slice_from_shape(shape: Tuple[int], slicing: slice) -> Tuple[Tuple[int], slice, List[int]]:
+    time_points = list(range(shape[0]))
+    if slicing is not None:
+        if isinstance(slicing, tuple):
+            time_points = time_points[slicing[0]]
+            volume_slicing = slicing[1:]
+            new_shape = (len(time_points),) + np.empty(shape=shape[1:], dtype=bool)[slicing[1:]].shape
+        else:
+            time_points = time_points[slicing]
+            volume_slicing = ...
+            new_shape = (len(time_points),) + shape[1:]
+    else:
+        volume_slicing = ...
+        new_shape = shape
+    return new_shape, volume_slicing, time_points

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ REQUIRED = [
     'click',
     'dask',
     'dask-image',
+    'dask-cuda',
     'distributed',
     'zarr',
     'cachey',
@@ -61,7 +62,8 @@ REQUIRED = [
     'python-telegram-bot',
     'PyYAML',
     'cairocffi',
-    'blosc'
+    'blosc',
+    'seaborn',
 ]
 
 # What packages are optional?


### PR DESCRIPTION
A previous update removed the use o delayed slicing during processing but resulted in a bug when slicing datasets with multiple channels. This fixes this bug.