### PR TITLE
docs readme updated

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,13 +6,7 @@
   python -m pip install -r requirements-docs.txt
 ```
 
-or `conda`
-
-```shell script
-  conda create -n dexpdocs -c conda-forge --file requirements-docs.txt
-  conda activate dexpdocs
-```
-
+Also make sure dexp and its all dependencies installed before trying to build the docs.
 
 After running ``make html`` the generated HTML documentation can be found in
 the ``build/html`` directory. Open ``build/html/index.html`` to view the home


### PR DESCRIPTION
some conda-forge versions were dropped so removed that and added a little clarification about dexp dependencies.