### PR TITLE
added pyopencl to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ conda activate dexp
 pip install dexp[color,cuda112,napari]
 ```
 
+Windows users should call `conda install -c conda-forge pyopencl` before running the last step.
+
 ### Leveraging extra CUDA libraries for faster processing:
 
 If you want you **dexp** CUDA-based processing to be even faster, you can install additional libraries such as CUDNN and CUTENSOR


### PR DESCRIPTION
Hi all,

I just tried installing dexp in a fresh conda environment on my windows computer. I ran into trouble because pyoppencl installation doesn't work on windows via pip. Adding this one sentence to the installation instructions may help future users.

dexp is amazing btw 🚀 🙂 

Cheers,
Robert